### PR TITLE
Replacing min()/max() with greaterThan()/lessThan() + atLeast()/atMost()

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ import Nope from 'nope-validator';
 
 const UserSchema = Nope.object().shape({
   name: Nope.string()
-    .min(5, 'Please provide a longer name')
-    .max(255, 'Name is too long!'),
+    .atLeast(5, 'Please provide a longer name')
+    .atMost(255, 'Name is too long!'),
   email: Nope.string()
     .email()
     .required(),
@@ -82,10 +82,10 @@ UserSchema.validate({
       test: Nope.string().when('check', {
         is: true,
         then: Nope.string()
-          .min(5, 'minError')
+          .atLeast(5, 'minError')
           .required(),
         otherwise: Nope.string()
-          .max(5)
+          .atMost(5)
           .required(),
       }),
     });
@@ -101,10 +101,10 @@ UserSchema.validate({
       test: Nope.string().when(['check', 'check2'], {
         is: (check, check2) => check && check2,
         then: Nope.string()
-          .min(5, 'minError')
+          .atLeast(5, 'minError')
           .required(),
         otherwise: Nope.string()
-          .max(5)
+          .atMost(5)
           .required(),
       }),
     });
@@ -196,25 +196,29 @@ UserSchema.validate({
       .validate('testgmail.com'); // returns the error message
     ```
 
-  - `min(length: number, message: string)` - Asserts if the entry is smaller than a threshold
+  - `min(length: number, message: string)` - **_deprecated_**: alias for greaterThan
+
+  - `max(length: number, message: string)` - **_deprecated_**: alias for lessThan
+
+  - `greaterThan(length: number, message: string)` - Asserts if the entry is smaller than a threshold
   - ```js
     Nope.string()
-      .min(4)
+      .greaterThan(4)
       .validate('https'); // returns undefined
 
     Nope.string()
-      .min(4)
+      .greaterThan(4)
       .validate('http'); // returns the error message
     ```
 
-  - `max(length: number, message: string)` - Asserts if the entry is greater than a threshold
+  - `lessThan(length: number, message: string)` - Asserts if the entry is greater than a threshold
   - ```js
     Nope.string()
-      .max(4)
+      .lessThan(4)
       .validate('url'); // returns undefined
 
     Nope.string()
-      .max(4)
+      .lessThan(4)
       .validate('http'); // returns the error message
     ```
 
@@ -231,25 +235,29 @@ UserSchema.validate({
       .validate(4.2); // returns the error message
     ```
 
-  - `min(size: number, message: string)` - Asserts if the entry is smaller than a threshold
+  - `min(size: number, message: string)` - **_deprecated_**: alias for greaterThan
+
+  - `max(size: number, message: string)` - **_deprecated_**: alias for lessThan
+
+  - `greaterThan(size: number, message: string)` - Asserts if the entry is smaller than a threshold
   - ```js
     Nope.number()
-      .min(1, 'error message')
+      .greaterThan(1, 'error message')
       .validate(2); // returns undefined
 
     Nope.number()
-      .min(1, 'error message')
+      .greaterThan(1, 'error message')
       .validate(1); // returns the error message
     ```
 
-  - `max(size: number, message: string)` - Asserts if the entry is greater than a threshold
+  - `lessThan(size: number, message: string)` - Asserts if the entry is greater than a threshold
   - ```js
     Nope.number()
-      .max(1, 'error message')
+      .lessThan(1, 'error message')
       .validate(-1); // returns undefined
 
     Nope.number()
-      .max(1, 'error message')
+      .lessThan(1, 'error message')
       .validate(2); // returns the error message
     ```
 
@@ -329,7 +337,7 @@ UserSchema.validate({
   - ```js
     const schema = Nope.object().shape({
       name: Nope.string()
-        .max(15)
+        .atMost(15)
         .required(),
       email: Nope.string()
         .email('Please provide a valid email')
@@ -348,7 +356,7 @@ UserSchema.validate({
 
   - ```js
     const baseSchema = Nope.object().shape({
-      password: Nope.string().min(5),
+      password: Nope.string().atLeast(5),
       confirmPassword: Nope.string()
         .oneOf([Nope.ref('password')], "Passwords don't match")
         .required(),
@@ -358,7 +366,7 @@ UserSchema.validate({
       .extend(baseSchema)
       .shape({
         name: Nope.string()
-          .min(4)
+          .atLeast(4)
           .required(),
       });
 
@@ -373,7 +381,7 @@ UserSchema.validate({
 
   - ```js
     const schema = Nope.object().shape({
-      name: Nope.string().min(5),
+      name: Nope.string().atLeast(5),
     }).noUnknown('no unknown keys');
 
     schema.validate({
@@ -390,7 +398,7 @@ UserSchema.validate({
     const schema = Nope.object().shape({
       email: Nope.string()
         .email()
-        .max(255)
+        .atMost(255)
         .required(),
       confirmEmail: Nope.string().oneOf([Nope.ref('email')], 'Must match the first email'),
     });
@@ -417,11 +425,11 @@ Instead of passing it through the `validationSchema` prop, you should call Nope'
 const schema = Nope.object().shape({
   email: Nope.string()
     .email()
-    .max(255)
+    .atMost(255)
     .required(),
   password: Nope.string()
-    .min(8)
-    .max(64)
+    .atLeast(8)
+    .atMost(64)
     .required(),
 });
 

--- a/src/NopeNumber.ts
+++ b/src/NopeNumber.ts
@@ -11,12 +11,26 @@ class NopeNumber extends NopePrimitive<number> {
       if (entry !== Math.floor(entry)) {
         return message;
       }
-    }
+    };
 
     return this.test(rule);
   }
 
-  public min(size: number, message = 'Input is too small') {
+  /**
+   * @deprecated alias for greaterThan()
+   */
+  public min(size: number, message?: string) {
+    return this.greaterThan(size, message);
+  }
+
+  /**
+   * @deprecated alias for lessThan()
+   */
+  public max(size: number, message?: string) {
+    return this.lessThan(size, message);
+  }
+
+  public greaterThan(size: number, message = 'Input is too small') {
     const rule: Rule<number> = entry => {
       if (entry === undefined || entry === null) {
         return;
@@ -30,7 +44,7 @@ class NopeNumber extends NopePrimitive<number> {
     return this.test(rule);
   }
 
-  public max(size: number, message = 'Input is too large') {
+  public lessThan(size: number, message = 'Input is too large') {
     const rule: Rule<number> = entry => {
       if (entry === undefined || entry === null) {
         return;
@@ -44,12 +58,40 @@ class NopeNumber extends NopePrimitive<number> {
     return this.test(rule);
   }
 
+  public atLeast(size: number, message = 'Input is too small') {
+    const rule: Rule<number> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry < size) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public atMost(size: number, message = 'Input is too large') {
+    const rule: Rule<number> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry > size) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
   public positive(message = 'Input must be positive') {
-    return this.min(0, message);
+    return this.greaterThan(0, message);
   }
 
   public negative(message = 'Input must be negative') {
-    return this.max(0, message);
+    return this.lessThan(0, message);
   }
 }
 

--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -25,7 +25,21 @@ class NopeString extends NopePrimitive<string> {
     return this.regex(emailRegex, message);
   }
 
-  public min(length: number, message = 'Input is too short') {
+  /**
+   * @deprecated alias for greaterThan()
+   */
+  public min(length: number, message?: string) {
+    return this.greaterThan(length, message);
+  }
+
+  /**
+   * @deprecated alias for lessThan()
+   */
+  public max(length: number, message?: string) {
+    return this.lessThan(length, message);
+  }
+
+  public greaterThan(length: number, message = 'Input is too short') {
     const rule: Rule<string> = entry => {
       if (entry === undefined || entry === null) {
         return;
@@ -39,13 +53,41 @@ class NopeString extends NopePrimitive<string> {
     return this.test(rule);
   }
 
-  public max(length: number, message = 'Input is too long') {
+  public lessThan(length: number, message = 'Input is too long') {
     const rule: Rule<string> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
 
       if (entry.length >= length) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public atLeast(length: number, message = 'Input is too short') {
+    const rule: Rule<string> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.length < length) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public atMost(length: number, message = 'Input is too long') {
+    const rule: Rule<string> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.length > length) {
         return message;
       }
     };

--- a/src/__tests__/NopeNumber.spec.ts
+++ b/src/__tests__/NopeNumber.spec.ts
@@ -2,15 +2,15 @@ import Nope from '..';
 
 describe('#NopeNumber', () => {
   describe('#min', () => {
-    it('should return undefined for an empty entry', () => {
+    it('(alias for greaterThan) should return undefined for an empty entry', () => {
       expect(
         Nope.number()
-          .min(5, 'minErrorMessage')
+          .min(5, 'minLengthErrorMessage')
           .validate(),
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is smaller or equal to the threshold', () => {
+    it('(alias for greaterThan) should return an error message for an entry smaller than the threshold', () => {
       expect(
         Nope.number()
           .min(5)
@@ -18,25 +18,33 @@ describe('#NopeNumber', () => {
       ).toBe('Input is too small');
     });
 
-    it('should return undefined for an entry greater than the threshold', () => {
+    it('(alias for greaterThan) should return an error message for an entry equal to the threshold', () => {
       expect(
         Nope.number()
-          .min(5, 'minErrorMessage')
+          .min(3)
+          .validate(3),
+      ).toBe('Input is too small');
+    });
+
+    it('(alias for greaterThan) should return undefined for an entry greater than the threshold', () => {
+      expect(
+        Nope.number()
+          .min(5, 'minLengthErrorMessage')
           .validate(6),
       ).toBe(undefined);
     });
   });
 
   describe('#max', () => {
-    it('should return undefined for an empty entry', () => {
+    it('(alias for lessThan) should return undefined for an empty entry', () => {
       expect(
         Nope.number()
-          .max(5, 'maxErrorMessage')
+          .max(5, 'maxLengthErrorMessage')
           .validate(),
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is greater than or equal to the max characters', () => {
+    it('(alias for lessThan) should return an error message for an entry greater than the threshold', () => {
       expect(
         Nope.number()
           .max(5)
@@ -44,36 +52,154 @@ describe('#NopeNumber', () => {
       ).toBe('Input is too large');
     });
 
-    it('should return undefined for an entry smaller than the threshold', () => {
+    it('(alias for lessThan) should return an error message for an entry equal to the threshold', () => {
       expect(
         Nope.number()
-          .max(5, 'maxErrorMessage')
+          .max(4)
+          .validate(4),
+      ).toBe('Input is too large');
+    });
+
+    it('(alias for lessThan) should return undefined for an entry smaller than the threshold', () => {
+      expect(
+        Nope.number()
+          .max(5, 'maxLengthErrorMessage')
           .validate(2),
       ).toBe(undefined);
     });
   });
 
-  describe('#max', () => {
+  describe('#greaterThan', () => {
     it('should return undefined for an empty entry', () => {
       expect(
         Nope.number()
-          .max(5, 'maxErrorMessage')
+          .greaterThan(5, 'greaterThanErrorMessage')
           .validate(),
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is greater than or equal to the max characters', () => {
+    it('should return an error message for an entry smaller than the threshold', () => {
       expect(
         Nope.number()
-          .max(5)
+          .greaterThan(5)
+          .validate(2),
+      ).toBe('Input is too small');
+    });
+
+    it('should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.number()
+          .greaterThan(3)
+          .validate(3),
+      ).toBe('Input is too small');
+    });
+
+    it('should return undefined for an entry greater than the threshold', () => {
+      expect(
+        Nope.number()
+          .greaterThan(5, 'greaterThanErrorMessage')
+          .validate(6),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#lessThan', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.number()
+          .lessThan(5, 'lessThanErrorMessage')
+          .validate(),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry greater than the threshold', () => {
+      expect(
+        Nope.number()
+          .lessThan(5)
           .validate(7),
+      ).toBe('Input is too large');
+    });
+
+    it('should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.number()
+          .lessThan(4)
+          .validate(4),
       ).toBe('Input is too large');
     });
 
     it('should return undefined for an entry smaller than the threshold', () => {
       expect(
         Nope.number()
-          .max(5, 'maxErrorMessage')
+          .lessThan(5, 'lessThanErrorMessage')
+          .validate(2),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#atLeast', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.number()
+          .atLeast(5, 'atLeastErrorMessage')
+          .validate(),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry smaller than the the threshold', () => {
+      expect(
+        Nope.number()
+          .atLeast(5)
+          .validate(2),
+      ).toBe('Input is too small');
+    });
+
+    it('should return undefined for an entry equal to the threshold', () => {
+      expect(
+        Nope.number()
+          .atLeast(3, 'atLeastErrorMessage')
+          .validate(3),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an entry greater than the threshold', () => {
+      expect(
+        Nope.number()
+          .atLeast(5, 'atLeastErrorMessage')
+          .validate(6),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#atMost', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.number()
+          .atMost(5, 'atMostErrorMessage')
+          .validate(),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry greater than the theshold', () => {
+      expect(
+        Nope.number()
+          .atMost(5)
+          .validate(7),
+      ).toBe('Input is too large');
+    });
+
+    it('should return undefined for an entry equal to the threshold', () => {
+      expect(
+        Nope.number()
+          .atMost(10, 'atMostErrorMessage')
+          .validate(10),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an entry smaller than the threshold', () => {
+      expect(
+        Nope.number()
+          .atMost(5, 'atMostErrorMessage')
           .validate(2),
       ).toBe(undefined);
     });
@@ -88,7 +214,7 @@ describe('#NopeNumber', () => {
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is negative', () => {
+    it('should return an error message for an entry negative', () => {
       expect(
         Nope.number()
           .positive()
@@ -96,7 +222,7 @@ describe('#NopeNumber', () => {
       ).toBe('Input must be positive');
     });
 
-    it('should return undefined for an entry that is positive', () => {
+    it('should return undefined for an entry positive', () => {
       expect(
         Nope.number()
           .positive('positiveErrorMessage')
@@ -114,7 +240,7 @@ describe('#NopeNumber', () => {
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is negative', () => {
+    it('should return an error message for an entry negative', () => {
       expect(
         Nope.number()
           .negative()
@@ -122,7 +248,7 @@ describe('#NopeNumber', () => {
       ).toBe('Input must be negative');
     });
 
-    it('should return undefined for an entry that is negative', () => {
+    it('should return undefined for an entry negative', () => {
       expect(
         Nope.number()
           .negative('negativeErrorMessage')
@@ -130,6 +256,7 @@ describe('#NopeNumber', () => {
       ).toBe(undefined);
     });
   });
+
   describe('#integer', () => {
     it('should return undefined for an empty entry', () => {
       expect(
@@ -139,7 +266,7 @@ describe('#NopeNumber', () => {
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is not an integer', () => {
+    it('should return an error message for an entry not an integer', () => {
       expect(
         Nope.number()
           .integer()
@@ -147,7 +274,7 @@ describe('#NopeNumber', () => {
       ).toBe('Input must be an integer');
     });
 
-    it('should return undefined for an entry that is an integer', () => {
+    it('should return undefined for an entry an integer', () => {
       expect(
         Nope.number()
           .integer('integerErrorMessage')

--- a/src/__tests__/NopeString.spec.ts
+++ b/src/__tests__/NopeString.spec.ts
@@ -80,7 +80,7 @@ describe('#NopeString', () => {
   });
 
   describe('#min', () => {
-    it('should return undefined for an empty entry', () => {
+    it('(alias for greaterThan) should return undefined for an empty entry', () => {
       expect(
         Nope.string()
           .min(5, 'minLengthErrorMessage')
@@ -88,7 +88,7 @@ describe('#NopeString', () => {
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is shorter or equal to the threshold', () => {
+    it('(alias for greaterThan) should return an error message for an entry shorter than the the threshold', () => {
       expect(
         Nope.string()
           .min(5)
@@ -96,7 +96,15 @@ describe('#NopeString', () => {
       ).toBe('Input is too short');
     });
 
-    it('should return undefined for an entry longer than the threshold', () => {
+    it('(alias for greaterThan) should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.string()
+          .min(4)
+          .validate('tour'),
+      ).toBe('Input is too short');
+    });
+
+    it('(alias for greaterThan) should return undefined for an entry longer than the threshold', () => {
       expect(
         Nope.string()
           .min(5, 'minLengthErrorMessage')
@@ -106,7 +114,7 @@ describe('#NopeString', () => {
   });
 
   describe('#max', () => {
-    it('should return undefined for an empty entry', () => {
+    it('(alias for lessThan) should return undefined for an empty entry', () => {
       expect(
         Nope.string()
           .max(5, 'maxLengthErrorMessage')
@@ -114,7 +122,7 @@ describe('#NopeString', () => {
       ).toBe(undefined);
     });
 
-    it('should return an error message for an entry that is longer or equal to the max characters', () => {
+    it('(alias for lessThan) should return an error message for an entry longer than the the threshold', () => {
       expect(
         Nope.string()
           .max(5)
@@ -122,10 +130,154 @@ describe('#NopeString', () => {
       ).toBe('Input is too long');
     });
 
-    it('should return undefined for an entry shorter than threshold', () => {
+    it('(alias for lessThan) should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.string()
+          .max(14)
+          .validate('magicalmystery'),
+      ).toBe('Input is too long');
+    });
+
+    it('(alias for lessThan) should return undefined for an entry shorter than threshold', () => {
       expect(
         Nope.string()
           .max(5, 'maxLengthErrorMessage')
+          .validate('tour'),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#greaterThan', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.string()
+          .greaterThan(5, 'greaterThanErrorMessage')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry shorter than the threshold', () => {
+      expect(
+        Nope.string()
+          .greaterThan(5)
+          .validate('tour'),
+      ).toBe('Input is too short');
+    });
+
+    it('should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.string()
+          .greaterThan(4)
+          .validate('tour'),
+      ).toBe('Input is too short');
+    });
+
+    it('should return undefined for an entry longer than the threshold', () => {
+      expect(
+        Nope.string()
+          .greaterThan(5, 'greaterThanErrorMessage')
+          .validate('magicalmystery'),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#lessThan', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.string()
+          .lessThan(5, 'lessThanErrorMessage')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry longer than the threshold', () => {
+      expect(
+        Nope.string()
+          .lessThan(5)
+          .validate('magicalmystery'),
+      ).toBe('Input is too long');
+    });
+
+    it('should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.string()
+          .lessThan(14)
+          .validate('magicalmystery'),
+      ).toBe('Input is too long');
+    });
+
+    it('should return undefined for an entry shorter than threshold', () => {
+      expect(
+        Nope.string()
+          .lessThan(5, 'lessThanErrorMessage')
+          .validate('tour'),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#atLeast', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.string()
+          .atLeast(5, 'atLeastErrorMessage')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry shorter than the threshold', () => {
+      expect(
+        Nope.string()
+          .atLeast(5)
+          .validate('tour'),
+      ).toBe('Input is too short');
+    });
+
+    it('should return undefined for an entry equal to the threshold', () => {
+      expect(
+        Nope.string()
+          .atLeast(4, 'atLeastErrorMessage')
+          .validate('tour'),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an entry longer than the threshold', () => {
+      expect(
+        Nope.string()
+          .atLeast(5, 'atLeastErrorMessage')
+          .validate('magicalmystery'),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#atMost', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.string()
+          .atMost(5, 'atMostErrorMessage')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry longer than the threshold', () => {
+      expect(
+        Nope.string()
+          .atMost(5)
+          .validate('magicalmystery'),
+      ).toBe('Input is too long');
+    });
+
+    it('should return undefined for an entry equal to the threshold', () => {
+      expect(
+        Nope.string()
+          .atMost(4, 'atMostErrorMessage')
+          .validate('tour'),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an entry shorter than threshold', () => {
+      expect(
+        Nope.string()
+          .atMost(5, 'atMostErrorMessage')
           .validate('tour'),
       ).toBe(undefined);
     });


### PR DESCRIPTION
### NopeString and NopeNumber:
- Added methods atLeast() and atMost()
- Renamed previous methods min() and max() to greaterThan() and lessThan(), respectively
- Created new methods min() and max() as aliases for greaterThan() and lessThan(), respectively

### NopeString.specs and NopeNumber.specs
- Added tests for atLeast() and atMost(), now also checking for equality
- Added tests for lessThan() and greaterThan(), now also checking for equality
- Added tests for min() and max(), a clone of tests from greaterThan() and lessThan(), to ensure aliases behave in the expected manner

### README
- NopeString and NopeNumber: replaced usage of min() and max() in examples with atLeast() and atMost()
- NopeString and NopeNumber: changed min() and max() methods on API section to reflect the fact that they are now deprecated aliases.
- NopeString and NopeNumber: added atLeast(), atMost(), greatherThan() and lessThan() to API section

Ran format, lint and test -> 👍
