### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,18 @@
+0.9.0
+Added 🚀
+- Number
+  - atLeast
+  - atMost
+  - greaterThan
+  - lessThan
+
+Internal 🏡
+- Fixed husky precommit hook
+- Replaced TSLint with ESLint
+- Bump @types/node to 12.6.6
+- Bump lodash to 4.17.4 in /benchmark
+- Bump lint-staged to 9.2.0
+
 0.8.1
 Fixes 🔨
 - Email validation flag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nope-validator",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "main": "lib/umd/index.js",
   "module": "lib/es2015/index.js",
   "types": "lib/umd/index.d.ts",


### PR DESCRIPTION
0.9.0
Added 🚀
- Number
  - atLeast
  - atMost
  - greaterThan
  - lessThan

Internal 🏡
- Fixed husky precommit hook
- Replaced TSLint with ESLint
- Bump @types/node to 12.6.6
- Bump lodash to 4.17.4 in /benchmark
- Bump lint-staged to 9.2.0