### PR TITLE
'array' validator type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,18 @@
+0.10.0
+Added 🚀
+- Array
+  - required
+  - type
+  - minLength
+  - maxLength
+  - mustContain
+  - hasOnly
+  - whereEvery
+  - whereSome
+
+Internal 🏡
+- Updated types/Validatable to support arrays
+
 0.9.0
 Added 🚀
 - Number

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,18 +1,3 @@
-0.10.0
-Added 🚀
-- Array
-  - required
-  - type
-  - minLength
-  - maxLength
-  - mustContain
-  - hasOnly
-  - whereEvery
-  - whereSome
-
-Internal 🏡
-- Updated types/Validatable to support arrays
-
 0.9.0
 Added 🚀
 - Number

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,8 +1,14 @@
 import { Rule, Validatable, Nil } from './types';
 import NopePrimitive from './NopePrimitive';
+import NopeObject from 'NopeObject';
 
 class NopeArray<T> implements Validatable<T[]> {
+  protected _type: string = 'object';
   public validationRules: Rule<T[]>[] = [];
+
+  public getType() {
+    return this._type;
+  }
 
   public required(message = 'This field is required') {
     const rule: Rule<T[]> = entry => {
@@ -14,7 +20,7 @@ class NopeArray<T> implements Validatable<T[]> {
     return this.test(rule);
   }
 
-  public of(primitive: NopePrimitive<T>, message = 'One or more elements are of invalid type') {
+  public of(primitive: Validatable<T>, message = 'One or more elements are of invalid type') {
     const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,7 +1,7 @@
 import { Rule, Validatable, Nil } from './types';
 import NopePrimitive from './NopePrimitive';
 
-class NopeArray<T extends any> implements Validatable<T[]> {
+class NopeArray<T> implements Validatable<T[]> {
   public validationRules: Rule<T[]>[] = [];
 
   public required(message = 'This field is required') {

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,5 +1,6 @@
 import { Rule, Validatable, Nil } from './types';
 import NopePrimitive from './NopePrimitive';
+import { deepEquals } from './utils';
 
 class NopeArray<T> implements Validatable<T[]> {
   protected _type: string = 'object';
@@ -87,7 +88,14 @@ class NopeArray<T> implements Validatable<T[]> {
         return;
       }
 
-      if (entry.some(value => values.indexOf(value) === -1)) {
+      if (
+        entry.some(value => {
+          if (typeof value === 'object') {
+            return !values.find(v => deepEquals(value, v));
+          }
+          return values.indexOf(value) === -1;
+        })
+      ) {
         return message;
       }
     };

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,0 +1,120 @@
+import { Rule, Validatable, Nil } from './types';
+import NopePrimitive from './NopePrimitive';
+
+class NopeArray implements Validatable<any[]> {
+  public validationRules: Rule<any[]>[] = [];
+
+  public required(message = 'This field is required') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public minLength(length: number, message = 'Input is too short') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.length <= length) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public maxLength(length: number, message = 'Input is too long') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.length >= length) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public mustContain(value: any, message = 'Input does not contain required value') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.indexOf(value) === -1) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public hasOnly(values: any[], message = 'Input elements must correspond to value values') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.some(value => values.indexOf(value) === -1)) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public whereEvery(callback: Function, message = 'Input does not satisfy condition') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.some(value => !callback(value))) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public whereSome(callback: Function, message = 'Input does not satisfy condition') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null || entry.length === 0) {
+        return;
+      }
+
+      if (!entry.some(value => callback(value))) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public test(rule: Rule<any[]>) {
+    this.validationRules.push(rule);
+
+    return this;
+  }
+
+  public validate(entry?: any[] | Nil, context?: object | undefined): string | undefined {
+    for (const rule of this.validationRules) {
+      const error = rule(entry, context);
+
+      if (error instanceof NopePrimitive) {
+        return error.validate(entry, context);
+      } else if (error) {
+        return `${error}`;
+      }
+    }
+  }
+}
+
+export default NopeArray;

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,6 +1,5 @@
 import { Rule, Validatable, Nil } from './types';
 import NopePrimitive from './NopePrimitive';
-import NopeObject from 'NopeObject';
 
 class NopeArray<T> implements Validatable<T[]> {
   protected _type: string = 'object';

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,5 +1,6 @@
-import { Rule, Validatable, Nil, Type } from './types';
+import { Rule, Validatable, Nil } from './types';
 import NopePrimitive from './NopePrimitive';
+import NopeObject from 'NopeObject';
 
 class NopeArray implements Validatable<any[]> {
   public validationRules: Rule<any[]>[] = [];
@@ -14,13 +15,13 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public type(type: Type, message = 'Not all values are of required type') {
+  public type(primitive: NopePrimitive<any>, message = 'Not all values are of required type') {
     const rule: Rule<any[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
 
-      if (entry.some(value => typeof value !== type)) {
+      if (entry.some(value => primitive.getType() !== typeof value)) {
         return message;
       }
     };

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,4 +1,4 @@
-import { Rule, Validatable, Nil } from './types';
+import { Rule, Validatable, Nil, Type } from './types';
 import NopePrimitive from './NopePrimitive';
 
 class NopeArray implements Validatable<any[]> {
@@ -7,6 +7,20 @@ class NopeArray implements Validatable<any[]> {
   public required(message = 'This field is required') {
     const rule: Rule<any[]> = entry => {
       if (entry === undefined || entry === null) {
+        return message;
+      }
+    };
+
+    return this.test(rule);
+  }
+
+  public type(type: Type, message = 'Not all values are of required type') {
+    const rule: Rule<any[]> = entry => {
+      if (entry === undefined || entry === null) {
+        return;
+      }
+
+      if (entry.some(value => typeof value !== type)) {
         return message;
       }
     };

--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,12 +1,11 @@
 import { Rule, Validatable, Nil } from './types';
 import NopePrimitive from './NopePrimitive';
-import NopeObject from 'NopeObject';
 
-class NopeArray implements Validatable<any[]> {
-  public validationRules: Rule<any[]>[] = [];
+class NopeArray<T extends any> implements Validatable<T[]> {
+  public validationRules: Rule<T[]>[] = [];
 
   public required(message = 'This field is required') {
-    const rule: Rule<any[]> = entry => {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return message;
       }
@@ -15,13 +14,19 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public type(primitive: NopePrimitive<any>, message = 'Not all values are of required type') {
-    const rule: Rule<any[]> = entry => {
+  public of(primitive: NopePrimitive<T>, message = 'One or more elements are of invalid type') {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
 
       if (entry.some(value => primitive.getType() !== typeof value)) {
+        return message;
+      }
+
+      const error = entry.find(value => primitive.validate(value));
+
+      if (error) {
         return message;
       }
     };
@@ -30,7 +35,7 @@ class NopeArray implements Validatable<any[]> {
   }
 
   public minLength(length: number, message = 'Input is too short') {
-    const rule: Rule<any[]> = entry => {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
@@ -44,7 +49,7 @@ class NopeArray implements Validatable<any[]> {
   }
 
   public maxLength(length: number, message = 'Input is too long') {
-    const rule: Rule<any[]> = entry => {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
@@ -57,8 +62,8 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public mustContain(value: any, message = 'Input does not contain required value') {
-    const rule: Rule<any[]> = entry => {
+  public mustContain(value: T, message = 'Input does not contain required value') {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
@@ -71,8 +76,8 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public hasOnly(values: any[], message = 'Input elements must correspond to value values') {
-    const rule: Rule<any[]> = entry => {
+  public hasOnly(values: T[], message = 'Input elements must correspond to value values') {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
@@ -85,8 +90,8 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public whereEvery(callback: Function, message = 'Input does not satisfy condition') {
-    const rule: Rule<any[]> = entry => {
+  public every(callback: Function, message = 'Input does not satisfy condition') {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null) {
         return;
       }
@@ -99,8 +104,8 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public whereSome(callback: Function, message = 'Input does not satisfy condition') {
-    const rule: Rule<any[]> = entry => {
+  public some(callback: Function, message = 'Input does not satisfy condition') {
+    const rule: Rule<T[]> = entry => {
       if (entry === undefined || entry === null || entry.length === 0) {
         return;
       }
@@ -113,13 +118,13 @@ class NopeArray implements Validatable<any[]> {
     return this.test(rule);
   }
 
-  public test(rule: Rule<any[]>) {
+  public test(rule: Rule<T[]>) {
     this.validationRules.push(rule);
 
     return this;
   }
 
-  public validate(entry?: any[] | Nil, context?: object | undefined): string | undefined {
+  public validate(entry?: T[] | Nil, context?: object | undefined): string | undefined {
     for (const rule of this.validationRules) {
       const error = rule(entry, context);
 

--- a/src/NopeBoolean.ts
+++ b/src/NopeBoolean.ts
@@ -2,6 +2,8 @@ import NopePrimitive from './NopePrimitive';
 import { Rule } from './types';
 
 class NopeBoolean extends NopePrimitive<boolean> {
+  protected _type: string = 'boolean';
+
   public true(message = 'Input must be true') {
     const rule: Rule<boolean> = entry => {
       if (entry === undefined || entry === null) {

--- a/src/NopeDate.ts
+++ b/src/NopeDate.ts
@@ -5,6 +5,8 @@ import { Rule } from './types';
 type T = string | number | Date;
 
 class NopeDate extends NopePrimitive<T> {
+  protected _type: string = 'object';
+
   public before(beforeDate: T, message = `Date must be before ${beforeDate.toString()}`) {
     const rule: Rule<T> = (entry, context) => {
       if (entry === null || entry === undefined) {

--- a/src/NopeNumber.ts
+++ b/src/NopeNumber.ts
@@ -2,6 +2,8 @@ import NopePrimitive from './NopePrimitive';
 import { Rule } from './types';
 
 class NopeNumber extends NopePrimitive<number> {
+  protected _type: string = 'number';
+
   public integer(message = 'Input must be an integer') {
     const rule: Rule<number> = entry => {
       if (entry === undefined || entry == null) {

--- a/src/NopePrimitive.ts
+++ b/src/NopePrimitive.ts
@@ -4,6 +4,11 @@ import { resolveNopeRefsFromKeys, every, resolveNopeRef } from './utils';
 
 abstract class NopePrimitive<T> implements Validatable<T> {
   protected validationRules: Rule<T>[] = [];
+  protected _type: string = 'undefined';
+
+  public getType() {
+    return this._type;
+  }
 
   public required(message = 'This field is required') {
     const rule: Rule<T> = entry => {

--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -3,6 +3,8 @@ import { Rule } from './types';
 import { urlRegex, emailRegex } from './consts';
 
 class NopeString extends NopePrimitive<string> {
+  protected _type: string = 'string';
+
   public regex(regex: RegExp, message = "Doesn't satisfy the rule") {
     const rule: Rule<string> = entry => {
       if (entry === undefined || entry === null) {

--- a/src/__tests__/NopeArray.spec.ts
+++ b/src/__tests__/NopeArray.spec.ts
@@ -1,0 +1,233 @@
+import Nope from '..';
+
+describe('#NopeArray', () => {
+  describe('#required', () => {
+    it('should return undefined for a non-nil entry', () => {
+      const validator = Nope.array().required();
+      expect(validator.validate([1, undefined, 'test'])).toEqual(undefined);
+      expect(validator.validate([])).toEqual(undefined);
+    });
+    it('should return an error message for a nil entry', () => {
+      const validator = Nope.array().required('requiredError');
+
+      expect(validator.required().validate(undefined)).toEqual('requiredError');
+      expect(validator.required().validate(null)).toEqual('requiredError');
+    });
+  });
+
+  describe('#minLength', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .minLength(5, 'minLengthErrorMessage')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry shorter than the the threshold', () => {
+      expect(
+        Nope.array()
+          .minLength(5)
+          .validate([1, 2, 3, 4]),
+      ).toBe('Input is too short');
+    });
+
+    it('should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.array()
+          .minLength(4)
+          .validate([1, 2, 3, 4]),
+      ).toBe('Input is too short');
+    });
+
+    it('should return undefined for an entry longer to the threshold', () => {
+      expect(
+        Nope.array()
+          .minLength(4)
+          .validate([1, 2, 3, 4, 5, 6]),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#maxLength', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .maxLength(5, 'maxLengthErrorMessage')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return an error message for an entry longer than the the threshold', () => {
+      expect(
+        Nope.array()
+          .maxLength(5)
+          .validate([1, 2, 3, 4, 5, 6]),
+      ).toBe('Input is too long');
+    });
+
+    it('should return an error message for an entry equal to the threshold', () => {
+      expect(
+        Nope.array()
+          .maxLength(4)
+          .validate([1, 2, 3, 4]),
+      ).toBe('Input is too long');
+    });
+
+    it('should return undefined for an entry shorter to the threshold', () => {
+      expect(
+        Nope.array()
+          .maxLength(4)
+          .validate([1, 2, 3]),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#mustContain', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .mustContain(2)
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return error message for an entry not containing the value passed', () => {
+      expect(
+        Nope.array()
+          .mustContain(2, 'containError')
+          .validate([1, 3, 4]),
+      ).toBe('containError');
+    });
+
+    it('should return undefined for an entry containing the value passed', () => {
+      expect(
+        Nope.array()
+          .mustContain(2, 'containError')
+          .validate([1, 2, 3, 4]),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an entry containing the value passed more than once', () => {
+      expect(
+        Nope.array()
+          .mustContain(2, 'containError')
+          .validate([1, 2, 3, 2, 4, 2]),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#hasOnly', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .hasOnly([1, 2, 3])
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return error message for an entry not containing any value passed', () => {
+      expect(
+        Nope.array()
+          .hasOnly([1, 2, 3], 'validateError')
+          .validate([4, 5, 6]),
+      ).toBe('validateError');
+    });
+
+    it('should return error message for an entry having different hasOnly from hasOnly passed', () => {
+      expect(
+        Nope.array()
+          .hasOnly([1, 2, 3], 'validateError')
+          .validate([1, 2, 3, 4, 5, 6]),
+      ).toBe('validateError');
+    });
+
+    it('should return undefined for an entry having only hasOnly from hasOnly passed', () => {
+      expect(
+        Nope.array()
+          .hasOnly([1, 2, 3], 'validateError')
+          .validate([1, 2, 1, 1, 3, 2]),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#whereEvery', () => {
+    const isEven = (value: number) => value % 2 === 0;
+
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .whereEvery(isEven)
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an empty array entry', () => {
+      expect(
+        Nope.array()
+          .whereEvery(isEven)
+          .validate([]),
+      ).toBe(undefined);
+    });
+
+    it('should return error message for an entry where some hasOnly fail the callback', () => {
+      expect(
+        Nope.array()
+          .whereEvery(isEven, 'whereEveryError')
+          .validate([2, 4, 5]),
+      ).toBe('whereEveryError');
+    });
+
+    it('should return undefined for an entry where all hasOnly succeed the callback', () => {
+      expect(
+        Nope.array()
+          .whereEvery(isEven)
+          .validate([2, 4, 6]),
+      ).toBe(undefined);
+    });
+  });
+
+  describe('#whereSome', () => {
+    const isEven = (value: number) => value % 2 === 0;
+
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .whereSome(isEven)
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an empty array entry', () => {
+      expect(
+        Nope.array()
+          .whereSome(isEven)
+          .validate([]),
+      ).toBe(undefined);
+    });
+
+    it('should return error message for an entry where all hasOnly fail the callback', () => {
+      expect(
+        Nope.array()
+          .whereSome(isEven, 'whereSomeError')
+          .validate([1, 3, 5]),
+      ).toBe('whereSomeError');
+    });
+
+    it('should return undefined for an entry where one value succeed the callback', () => {
+      expect(
+        Nope.array()
+          .whereSome(isEven)
+          .validate([1, 2, 3]),
+      ).toBe(undefined);
+    });
+
+    it('should return undefined for an entry where all value succeed the callback', () => {
+      expect(
+        Nope.array()
+          .whereSome(isEven)
+          .validate([2, 4, 6]),
+      ).toBe(undefined);
+    });
+  });
+});

--- a/src/__tests__/NopeArray.spec.ts
+++ b/src/__tests__/NopeArray.spec.ts
@@ -19,7 +19,7 @@ describe('#NopeArray', () => {
     it('should return undefined for an empty entry', () => {
       expect(
         Nope.array()
-          .type('number')
+          .type(Nope.boolean())
           .validate(undefined),
       ).toBe(undefined);
     });
@@ -27,7 +27,7 @@ describe('#NopeArray', () => {
     it('should return error message for an entry whose values are not all of the required type', () => {
       expect(
         Nope.array()
-          .type('number', 'typeError')
+          .type(Nope.number(), 'typeError')
           .validate([1, 2, '3']),
       ).toBe('typeError');
     });
@@ -35,7 +35,7 @@ describe('#NopeArray', () => {
     it('should return undefined for an entry whose values are all of the required type', () => {
       expect(
         Nope.array()
-          .type('number')
+          .type(Nope.number())
           .validate([1, 2, 3]),
       ).toBe(undefined);
     });

--- a/src/__tests__/NopeArray.spec.ts
+++ b/src/__tests__/NopeArray.spec.ts
@@ -196,6 +196,23 @@ describe('#NopeArray', () => {
           .validate([1, 2, 1, 1, 3, 2]),
       ).toBe(undefined);
     });
+
+    it('should return for correct object comparison', () => {
+      expect(
+        Nope.array<any>()
+          .of(Nope.array<any>().of(Nope.string()))
+          .hasOnly([['a']])
+          .validate([['a']]),
+      ).toBe(undefined);
+    });
+    it('should return an error message for invalid object comparison', () => {
+      expect(
+        Nope.array<any>()
+          .of(Nope.array<any>().of(Nope.string()))
+          .hasOnly([['a']], 'invalidEntries')
+          .validate([['b']]),
+      ).toBe('invalidEntries');
+    });
   });
 
   describe('#every', () => {

--- a/src/__tests__/NopeArray.spec.ts
+++ b/src/__tests__/NopeArray.spec.ts
@@ -15,6 +15,32 @@ describe('#NopeArray', () => {
     });
   });
 
+  describe('#test', () => {
+    it('should return undefined for an empty entry', () => {
+      expect(
+        Nope.array()
+          .type('number')
+          .validate(undefined),
+      ).toBe(undefined);
+    });
+
+    it('should return error message for an entry whose values are not all of the required type', () => {
+      expect(
+        Nope.array()
+          .type('number', 'typeError')
+          .validate([1, 2, '3']),
+      ).toBe('typeError');
+    });
+
+    it('should return undefined for an entry whose values are all of the required type', () => {
+      expect(
+        Nope.array()
+          .type('number')
+          .validate([1, 2, 3]),
+      ).toBe(undefined);
+    });
+  });
+
   describe('#minLength', () => {
     it('should return undefined for an empty entry', () => {
       expect(

--- a/src/__tests__/NopeArray.spec.ts
+++ b/src/__tests__/NopeArray.spec.ts
@@ -3,12 +3,12 @@ import Nope from '..';
 describe('#NopeArray', () => {
   describe('#required', () => {
     it('should return undefined for a non-nil entry', () => {
-      const validator = Nope.array().required();
+      const validator = Nope.array<any>().required();
       expect(validator.validate([1, undefined, 'test'])).toEqual(undefined);
       expect(validator.validate([])).toEqual(undefined);
     });
     it('should return an error message for a nil entry', () => {
-      const validator = Nope.array().required('requiredError');
+      const validator = Nope.array<any>().required('requiredError');
 
       expect(validator.required().validate(undefined)).toEqual('requiredError');
       expect(validator.required().validate(null)).toEqual('requiredError');
@@ -18,7 +18,7 @@ describe('#NopeArray', () => {
   describe('#of', () => {
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .of(Nope.boolean())
           .validate(undefined),
       ).toBe(undefined);
@@ -26,7 +26,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry whose values are not all of the required of', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .of(Nope.number(), 'ofError')
           .validate([1, 2, 'sda']),
       ).toBe('ofError');
@@ -34,7 +34,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry whose values do not get validated differ from primitive validation', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .of(Nope.number().atLeast(4), 'ofError')
           .validate([6, 5, 3]),
       ).toBe('ofError');
@@ -42,7 +42,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry whose values do not get validated differ from primitive validation', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .of(
             Nope.number()
               .atLeast(4)
@@ -55,7 +55,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry whose values are all of the required of', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .of(Nope.number().atMost(3))
           .validate([1, 2, 3]),
       ).toBe(undefined);
@@ -65,7 +65,7 @@ describe('#NopeArray', () => {
   describe('#minLength', () => {
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .minLength(5, 'minLengthErrorMessage')
           .validate(undefined),
       ).toBe(undefined);
@@ -73,7 +73,7 @@ describe('#NopeArray', () => {
 
     it('should return an error message for an entry shorter than the the threshold', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .minLength(5)
           .validate([1, 2, 3, 4]),
       ).toBe('Input is too short');
@@ -81,7 +81,7 @@ describe('#NopeArray', () => {
 
     it('should return an error message for an entry equal to the threshold', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .minLength(4)
           .validate([1, 2, 3, 4]),
       ).toBe('Input is too short');
@@ -89,7 +89,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry longer to the threshold', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .minLength(4)
           .validate([1, 2, 3, 4, 5, 6]),
       ).toBe(undefined);
@@ -99,7 +99,7 @@ describe('#NopeArray', () => {
   describe('#maxLength', () => {
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .maxLength(5, 'maxLengthErrorMessage')
           .validate(undefined),
       ).toBe(undefined);
@@ -107,7 +107,7 @@ describe('#NopeArray', () => {
 
     it('should return an error message for an entry longer than the the threshold', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .maxLength(5)
           .validate([1, 2, 3, 4, 5, 6]),
       ).toBe('Input is too long');
@@ -115,7 +115,7 @@ describe('#NopeArray', () => {
 
     it('should return an error message for an entry equal to the threshold', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .maxLength(4)
           .validate([1, 2, 3, 4]),
       ).toBe('Input is too long');
@@ -123,7 +123,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry shorter to the threshold', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .maxLength(4)
           .validate([1, 2, 3]),
       ).toBe(undefined);
@@ -133,7 +133,7 @@ describe('#NopeArray', () => {
   describe('#mustContain', () => {
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .mustContain(2)
           .validate(undefined),
       ).toBe(undefined);
@@ -141,7 +141,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry not containing the value passed', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .mustContain(2, 'containError')
           .validate([1, 3, 4]),
       ).toBe('containError');
@@ -149,7 +149,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry containing the value passed', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .mustContain(2, 'containError')
           .validate([1, 2, 3, 4]),
       ).toBe(undefined);
@@ -157,7 +157,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry containing the value passed more than once', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .mustContain(2, 'containError')
           .validate([1, 2, 3, 2, 4, 2]),
       ).toBe(undefined);
@@ -167,7 +167,7 @@ describe('#NopeArray', () => {
   describe('#hasOnly', () => {
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .hasOnly([1, 2, 3])
           .validate(undefined),
       ).toBe(undefined);
@@ -175,7 +175,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry not containing any value passed', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .hasOnly([1, 2, 3], 'validateError')
           .validate([4, 5, 6]),
       ).toBe('validateError');
@@ -183,7 +183,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry having different hasOnly from hasOnly passed', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .hasOnly([1, 2, 3], 'validateError')
           .validate([1, 2, 3, 4, 5, 6]),
       ).toBe('validateError');
@@ -191,7 +191,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry having only hasOnly from hasOnly passed', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .hasOnly([1, 2, 3], 'validateError')
           .validate([1, 2, 1, 1, 3, 2]),
       ).toBe(undefined);
@@ -203,7 +203,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .every(isEven)
           .validate(undefined),
       ).toBe(undefined);
@@ -211,7 +211,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an empty array entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .every(isEven)
           .validate([]),
       ).toBe(undefined);
@@ -219,7 +219,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry where some hasOnly fail the callback', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .every(isEven, 'everyError')
           .validate([2, 4, 5]),
       ).toBe('everyError');
@@ -227,7 +227,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry where all hasOnly succeed the callback', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .every(isEven)
           .validate([2, 4, 6]),
       ).toBe(undefined);
@@ -239,7 +239,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an empty entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .some(isEven)
           .validate(undefined),
       ).toBe(undefined);
@@ -247,7 +247,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an empty array entry', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .some(isEven)
           .validate([]),
       ).toBe(undefined);
@@ -255,7 +255,7 @@ describe('#NopeArray', () => {
 
     it('should return error message for an entry where all hasOnly fail the callback', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .some(isEven, 'whereSomeError')
           .validate([1, 3, 5]),
       ).toBe('whereSomeError');
@@ -263,7 +263,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry where one value succeed the callback', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .some(isEven)
           .validate([1, 2, 3]),
       ).toBe(undefined);
@@ -271,7 +271,7 @@ describe('#NopeArray', () => {
 
     it('should return undefined for an entry where all value succeed the callback', () => {
       expect(
-        Nope.array()
+        Nope.array<any>()
           .some(isEven)
           .validate([2, 4, 6]),
       ).toBe(undefined);

--- a/src/__tests__/NopeArray.spec.ts
+++ b/src/__tests__/NopeArray.spec.ts
@@ -15,27 +15,48 @@ describe('#NopeArray', () => {
     });
   });
 
-  describe('#test', () => {
+  describe('#of', () => {
     it('should return undefined for an empty entry', () => {
       expect(
         Nope.array()
-          .type(Nope.boolean())
+          .of(Nope.boolean())
           .validate(undefined),
       ).toBe(undefined);
     });
 
-    it('should return error message for an entry whose values are not all of the required type', () => {
+    it('should return error message for an entry whose values are not all of the required of', () => {
       expect(
         Nope.array()
-          .type(Nope.number(), 'typeError')
-          .validate([1, 2, '3']),
-      ).toBe('typeError');
+          .of(Nope.number(), 'ofError')
+          .validate([1, 2, 'sda']),
+      ).toBe('ofError');
     });
 
-    it('should return undefined for an entry whose values are all of the required type', () => {
+    it('should return error message for an entry whose values do not get validated differ from primitive validation', () => {
       expect(
         Nope.array()
-          .type(Nope.number())
+          .of(Nope.number().atLeast(4), 'ofError')
+          .validate([6, 5, 3]),
+      ).toBe('ofError');
+    });
+
+    it('should return error message for an entry whose values do not get validated differ from primitive validation', () => {
+      expect(
+        Nope.array()
+          .of(
+            Nope.number()
+              .atLeast(4)
+              .atMost(9),
+            'ofError',
+          )
+          .validate([6, 5, 10]),
+      ).toBe('ofError');
+    });
+
+    it('should return undefined for an entry whose values are all of the required of', () => {
+      expect(
+        Nope.array()
+          .of(Nope.number().atMost(3))
           .validate([1, 2, 3]),
       ).toBe(undefined);
     });
@@ -177,13 +198,13 @@ describe('#NopeArray', () => {
     });
   });
 
-  describe('#whereEvery', () => {
+  describe('#every', () => {
     const isEven = (value: number) => value % 2 === 0;
 
     it('should return undefined for an empty entry', () => {
       expect(
         Nope.array()
-          .whereEvery(isEven)
+          .every(isEven)
           .validate(undefined),
       ).toBe(undefined);
     });
@@ -191,7 +212,7 @@ describe('#NopeArray', () => {
     it('should return undefined for an empty array entry', () => {
       expect(
         Nope.array()
-          .whereEvery(isEven)
+          .every(isEven)
           .validate([]),
       ).toBe(undefined);
     });
@@ -199,27 +220,27 @@ describe('#NopeArray', () => {
     it('should return error message for an entry where some hasOnly fail the callback', () => {
       expect(
         Nope.array()
-          .whereEvery(isEven, 'whereEveryError')
+          .every(isEven, 'everyError')
           .validate([2, 4, 5]),
-      ).toBe('whereEveryError');
+      ).toBe('everyError');
     });
 
     it('should return undefined for an entry where all hasOnly succeed the callback', () => {
       expect(
         Nope.array()
-          .whereEvery(isEven)
+          .every(isEven)
           .validate([2, 4, 6]),
       ).toBe(undefined);
     });
   });
 
-  describe('#whereSome', () => {
+  describe('#some', () => {
     const isEven = (value: number) => value % 2 === 0;
 
     it('should return undefined for an empty entry', () => {
       expect(
         Nope.array()
-          .whereSome(isEven)
+          .some(isEven)
           .validate(undefined),
       ).toBe(undefined);
     });
@@ -227,7 +248,7 @@ describe('#NopeArray', () => {
     it('should return undefined for an empty array entry', () => {
       expect(
         Nope.array()
-          .whereSome(isEven)
+          .some(isEven)
           .validate([]),
       ).toBe(undefined);
     });
@@ -235,7 +256,7 @@ describe('#NopeArray', () => {
     it('should return error message for an entry where all hasOnly fail the callback', () => {
       expect(
         Nope.array()
-          .whereSome(isEven, 'whereSomeError')
+          .some(isEven, 'whereSomeError')
           .validate([1, 3, 5]),
       ).toBe('whereSomeError');
     });
@@ -243,7 +264,7 @@ describe('#NopeArray', () => {
     it('should return undefined for an entry where one value succeed the callback', () => {
       expect(
         Nope.array()
-          .whereSome(isEven)
+          .some(isEven)
           .validate([1, 2, 3]),
       ).toBe(undefined);
     });
@@ -251,7 +272,7 @@ describe('#NopeArray', () => {
     it('should return undefined for an entry where all value succeed the callback', () => {
       expect(
         Nope.array()
-          .whereSome(isEven)
+          .some(isEven)
           .validate([2, 4, 6]),
       ).toBe(undefined);
     });

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -18,4 +18,13 @@ describe('#utils', () => {
       ]);
     });
   });
+
+  describe('#deepEquals', () => {
+    it('should work', () => {
+      expect(utils.deepEquals({ a: 42 }, { b: 42 })).toEqual(false);
+      expect(utils.deepEquals({ a: [[42]] }, { a: [[42]] })).toEqual(true);
+      expect(utils.deepEquals({ a: [[2, { a: 42 }]] }, { a: [[2, { a: 42 }]] })).toEqual(true);
+      expect(utils.deepEquals({ a: [[2, { a: 42 }]] }, { a: [[2, { a: 41 }]] })).toEqual(false);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const NopeObjectConstructor = () => new NopeObject();
 const NopeStringConstructor = () => new NopeString();
 const NopeNumberConstructor = () => new NopeNumber();
 const NopeBooleanConstructor = () => new NopeBoolean();
-const NopeArrayConstructor = () => new NopeArray();
+const NopeArrayConstructor = <T>() => new NopeArray<T>();
 const NopeDateConstructor = () => new NopeDate();
 const NopeReferenceConstructor = (key: string) => new NopeReference(key);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import NopeObject from './NopeObject';
 import NopeString from './NopeString';
 import NopeNumber from './NopeNumber';
 import NopeBoolean from './NopeBoolean';
+import NopeArray from './NopeArray';
 import NopeDate from './NopeDate';
 import NopeReference from './NopeReference';
 
@@ -9,6 +10,7 @@ const NopeObjectConstructor = () => new NopeObject();
 const NopeStringConstructor = () => new NopeString();
 const NopeNumberConstructor = () => new NopeNumber();
 const NopeBooleanConstructor = () => new NopeBoolean();
+const NopeArrayConstructor = () => new NopeArray();
 const NopeDateConstructor = () => new NopeDate();
 const NopeReferenceConstructor = (key: string) => new NopeReference(key);
 
@@ -17,6 +19,7 @@ const Nope = {
   string: NopeStringConstructor,
   number: NopeNumberConstructor,
   boolean: NopeBooleanConstructor,
+  array: NopeArrayConstructor,
   date: NopeDateConstructor,
   ref: NopeReferenceConstructor,
 };
@@ -27,6 +30,7 @@ export {
   NopeNumberConstructor as number,
   NopeStringConstructor as string,
   NopeBooleanConstructor as boolean,
+  NopeArrayConstructor as array,
   NopeDateConstructor as date,
   NopeReferenceConstructor as ref,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,13 +17,3 @@ export interface ShapeErrors {
 }
 
 export type Nil = null | undefined;
-
-export type Type =
-  | 'undefined'
-  | 'object'
-  | 'boolean'
-  | 'number'
-  | 'bigInt'
-  | 'string'
-  | 'symbol'
-  | 'function';

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type Rule<T> = (
 ) => string | undefined | NopePrimitive<T>;
 
 export interface Validatable<T> {
-  validate: Rule<T>;
+  validate: Rule<T> | Rule<T[]>;
 }
 
 export interface ShapeErrors {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,13 @@ export interface ShapeErrors {
 }
 
 export type Nil = null | undefined;
+
+export type Type =
+  | 'undefined'
+  | 'object'
+  | 'boolean'
+  | 'number'
+  | 'bigInt'
+  | 'string'
+  | 'symbol'
+  | 'function';

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,8 @@ export type Rule<T> = (
 ) => string | undefined | NopePrimitive<T>;
 
 export interface Validatable<T> {
-  validate: Rule<T> | Rule<T[]>;
+  validate: Rule<T>;
+  getType: () => string;
 }
 
 export interface ShapeErrors {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,3 +30,39 @@ export function resolveNopeRef<T>(
 
   return option;
 }
+
+export function deepEquals(a: any, b: any): boolean {
+  if (typeof a == 'object' && a != null && (typeof b == 'object' && b != null)) {
+    if (a === b) {
+      return true;
+    }
+
+    let aCount = 0;
+    let bCount = 0;
+
+    for (const _ in a) {
+      aCount++;
+    }
+    for (const _ in b) {
+      bCount++;
+    }
+
+    if (aCount - bCount !== 0) {
+      return false;
+    }
+
+    for (const key in a) {
+      if (!(key in b) || !deepEquals(a[key], b[key])) {
+        return false;
+      }
+    }
+    for (const key in b) {
+      if (!(key in a) || !deepEquals(b[key], a[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return a === b;
+}


### PR DESCRIPTION
# Description
Added the array validator type with methods:
  - required
  - type
  - minLength
  - maxLength
  - mustContain
  - hasOnly
  - whereEvery
  - whereSome

Also had to update types.ts:
 - interface Validator can now return Rule<T[]> in order for the array to work with the already defined Object validator
 - added a new type 'Type' for the NopeArray.type method to evaluate if all values within the entry array are of the required type

Fixes # (50)
[Missing `array` validator type](https://github.com/bvego/nope-validator/issues/50)
