### PR TITLE
Release v0.11.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+0.11.3
+
+Fixes 🔨
+- Date
+  - before (reference type argument)
+  - after (reference type argument)
+
+Internal 🏡
+- Bump ts-jest to 25.5.1
+- Bump @typescript-eslint/eslint-plugin to 2.32.0
+- Bump @typescript-eslint/parser to 2.32.0
+
 0.11.2
 
 Added 🚀

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nope-validator",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "main": "lib/umd/index.js",
   "module": "lib/es2015/index.js",
   "types": "lib/umd/index.d.ts",


### PR DESCRIPTION
Fixes 🔨
- Date
  - before (reference type argument)
  - after (reference type argument)

Internal 🏡
- Bump ts-jest to 25.5.1
- Bump @typescript-eslint/eslint-plugin to 2.32.0
- Bump @typescript-eslint/parser to 2.32.0