### PR TITLE
feat: create between method for String validations

### DIFF
--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -114,6 +114,25 @@ export class NopeString extends NopePrimitive<string> {
     return this.test(rule);
   }
 
+  public between(
+    startLength: number,
+    endLength: number,
+    atLeastMessage = 'Input is too short',
+    atMostMessage = 'Input is too long',
+  ) {
+    if (startLength && endLength && startLength > endLength) {
+      const rule: Rule<unknown> = () => {
+        throw Error(
+          'between must receive an initial length (startLength) smaller than the final length (endLength) parameter',
+        );
+      };
+
+      return this.test(rule);
+    }
+
+    return this.atLeast(startLength, atLeastMessage) && this.atMost(endLength, atMostMessage);
+  }
+
   public exactLength(length: number, message = `Must be at exactly of length ${length}`) {
     const rule: Rule<string> = (entry) => {
       if (this.isEmpty(entry)) {

--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -130,7 +130,10 @@ export class NopeString extends NopePrimitive<string> {
       return this.test(rule);
     }
 
-    return this.atLeast(startLength, atLeastMessage) && this.atMost(endLength, atMostMessage);
+    this.atLeast(startLength, atLeastMessage);
+    this.atMost(endLength, atMostMessage);
+
+    return this;
   }
 
   public exactLength(length: number, message = `Must be at exactly of length ${length}`) {

--- a/src/__tests__/NopeString.spec.ts
+++ b/src/__tests__/NopeString.spec.ts
@@ -227,6 +227,41 @@ describe('#NopeString', () => {
     });
   });
 
+  describe('#between', () => {
+    it('should return undefined for an empty entry', async () => {
+      const schema = Nope.string().between(5, 10, 'atLeastErrorMessage', 'atMostErrorMessage');
+      await validateSyncAndAsync(schema, undefined, undefined);
+    });
+
+    it('should return an error message for an entry shorter than the threshold', async () => {
+      const schema = Nope.string().between(5, 10);
+      await validateSyncAndAsync(schema, 'tour', 'Input is too short');
+    });
+
+    it('should return undefined for an entry equal to the threshold', async () => {
+      const schema = Nope.string().between(4, 10);
+      await validateSyncAndAsync(schema, 'tour', undefined);
+    });
+
+    it('should return an error message for an entry longer than the threshold', async () => {
+      const schema = Nope.string().between(5, 6);
+      await validateSyncAndAsync(schema, 'magicalmystery', 'Input is too long');
+    });
+
+    it('should return undefined for both equal entries to the threshold', async () => {
+      const schema = Nope.string().between(5, 5);
+      await validateSyncAndAsync(schema, 'seven', undefined);
+    });
+
+    it('should throw an error if used wrongly', () => {
+      const schema = Nope.string().between(5, 1);
+
+      expect(() => {
+        schema.validate({ example: 42 });
+      }).toThrowError();
+    });
+  });
+
   describe('#required', () => {
     it('should return requiredMessage for undefined', async () => {
       const schema = Nope.string().required('requiredMessage');


### PR DESCRIPTION
Hi, thanks for your cool project, I'm using it for at least 10 days (`atLeast (10, 'days')`) and I'm very satisfied.

# Description

I would like to propose the creation of a `between` method to avoid typing so much every time that it is necessary to create rules for `atLeast` and `atMost` at the same time.

----

My suggestion is to create a method that will allow us **to write**:
`Nope.string().between(5, 255, 'Please provide a longer name', 'Name is too long!')`

**instead of:**
`Nope.string().atLeast(5, 'Please provide a longer name').atMost(255, 'Name is too long!')`

I hope you can see the benefits of this change ;)

Thank you,
Ademílson