### PR TITLE
feat: create between method for Number validations

### DIFF
--- a/src/NopeNumber.ts
+++ b/src/NopeNumber.ts
@@ -83,6 +83,28 @@ export class NopeNumber extends NopePrimitive<number> {
     return this.test(rule);
   }
 
+  public between(
+    sizeStart: number,
+    sizeEnd: number,
+    atLeastMessage = 'Input is too small',
+    atMostMessage = 'Input is too large',
+  ) {
+    if (sizeStart && sizeEnd && sizeStart > sizeEnd) {
+      const rule: Rule<unknown> = () => {
+        throw Error(
+          'between must receive an initial size (sizeStart) smaller than the final size (sizeEnd) parameter',
+        );
+      };
+
+      return this.test(rule);
+    }
+
+    this.atLeast(sizeStart, atLeastMessage);
+    this.atMost(sizeEnd, atMostMessage);
+
+    return this;
+  }
+
   public positive(message = 'Input must be positive') {
     return this.greaterThan(0, message);
   }

--- a/src/__tests__/NopeNumber.spec.ts
+++ b/src/__tests__/NopeNumber.spec.ts
@@ -138,6 +138,45 @@ describe('#NopeNumber', () => {
     });
   });
 
+  describe('#between', () => {
+    it('should return an error message for an entry smaller than the the threshold', async () => {
+      await validateSyncAndAsync(Nope.number().between(5, 10), 2, 'Input is too small');
+    });
+
+    it('should return undefined for an entry equal (startSize) to the threshold', async () => {
+      await validateSyncAndAsync(Nope.number().between(3, 10, 'atLeastErrorMessage'), 3, undefined);
+    });
+
+    it('should return an error message for an entry greater than the theshold', async () => {
+      await validateSyncAndAsync(
+        Nope.number().between(5, 6, 'tooSmall', 'tooLarge'),
+        7,
+        'tooLarge',
+      );
+    });
+
+    it('should return undefined for an entry equal (endSize) to the threshold', async () => {
+      await validateSyncAndAsync(
+        Nope.number().between(10, 15, 'atMostErrorMessage'),
+        10,
+        undefined,
+      );
+    });
+
+    it('should return undefined for an empty entry', async () => {
+      const schema = Nope.number().between(5, 10, 'atLeastErrorMessage', 'atMostErrorMessage');
+      await validateSyncAndAsync(schema, undefined, undefined);
+    });
+
+    it('should throw an error if used wrongly', () => {
+      const schema = Nope.number().between(5, 1);
+
+      expect(() => {
+        schema.validate(0);
+      }).toThrowError();
+    });
+  });
+
   describe('#positive', () => {
     it('should return undefined for an empty entry', async () => {
       await validateSyncAndAsync(Nope.number().positive(), undefined, undefined);

--- a/src/__tests__/NopeString.spec.ts
+++ b/src/__tests__/NopeString.spec.ts
@@ -238,9 +238,14 @@ describe('#NopeString', () => {
       await validateSyncAndAsync(schema, 'tour', 'Input is too short');
     });
 
-    it('should return undefined for an entry equal to the threshold', async () => {
+    it('should return undefined for an entry equal (startLength) to the threshold', async () => {
       const schema = Nope.string().between(4, 10);
       await validateSyncAndAsync(schema, 'tour', undefined);
+    });
+
+    it('should return undefined for an entry equal (endLength) to the threshold', async () => {
+      const schema = Nope.string().between(4, 10);
+      await validateSyncAndAsync(schema, '1234567890', undefined);
     });
 
     it('should return an error message for an entry longer than the threshold', async () => {
@@ -257,7 +262,7 @@ describe('#NopeString', () => {
       const schema = Nope.string().between(5, 1);
 
       expect(() => {
-        schema.validate({ example: 42 });
+        schema.validate('John Doe');
       }).toThrowError();
     });
   });


### PR DESCRIPTION
Hi again,

# Description

I would like to propose the creation of a `between` for **Numbers** with the same purpose of [my last pull-request](ftonato:feature/create-between-method-for-strings).

Thank you,
Ademílson