### PR TITLE
feat: add isNil method

### DIFF
--- a/src/NopeArray.ts
+++ b/src/NopeArray.ts
@@ -1,6 +1,6 @@
 import { Rule, Validatable } from './types';
 import { NopePrimitive } from './NopePrimitive';
-import { deepEquals, runValidators } from './utils';
+import { deepEquals, isNil, runValidators } from './utils';
 import { NopeObject } from './NopeObject';
 
 function ofType(entry: any, primitive: any) {
@@ -31,7 +31,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public required(message = 'This field is required') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return message;
       }
     };
@@ -46,7 +46,7 @@ export class NopeArray<T> implements Validatable<T[]> {
     this.ofShape = primitive;
 
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -71,7 +71,7 @@ export class NopeArray<T> implements Validatable<T[]> {
     this.ofShape = primitive;
 
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -87,7 +87,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public minLength(length: number, message = 'Input is too short') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -101,7 +101,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public maxLength(length: number, message = 'Input is too long') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -115,7 +115,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public mustContain(value: T, message = 'Input does not contain required value') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -129,7 +129,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public hasOnly(values: T[], message = 'Input elements must correspond to value values') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -150,7 +150,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public every(callback: (value: T) => boolean, message = 'Input does not satisfy condition') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null) {
+      if (isNil(entry)) {
         return;
       }
 
@@ -164,7 +164,7 @@ export class NopeArray<T> implements Validatable<T[]> {
 
   public some(callback: (value: T) => boolean, message = 'Input does not satisfy condition') {
     const rule: Rule<T[]> = (entry) => {
-      if (entry === undefined || entry === null || entry.length === 0) {
+      if (isNil(entry) || entry.length === 0) {
         return;
       }
 

--- a/src/NopeBoolean.ts
+++ b/src/NopeBoolean.ts
@@ -1,5 +1,6 @@
 import { NopePrimitive } from './NopePrimitive';
 import { Rule } from './types';
+import { isNil } from './utils';
 
 export class NopeBoolean extends NopePrimitive<boolean> {
   protected _type = 'boolean';
@@ -33,7 +34,7 @@ export class NopeBoolean extends NopePrimitive<boolean> {
   }
 
   public validate(entry?: any, context?: Record<string | number, unknown>): string | undefined {
-    const value = entry === undefined || entry === null ? entry : !!entry;
+    const value = isNil(entry) ? entry : !!entry;
 
     return super.validate(value, context);
   }
@@ -42,7 +43,7 @@ export class NopeBoolean extends NopePrimitive<boolean> {
     entry?: any,
     context?: Record<string | number, unknown>,
   ): Promise<string | undefined> {
-    const value = entry === undefined || entry === null ? entry : !!entry;
+    const value = isNil(entry) ? entry : !!entry;
 
     return super.validateAsync(value, context);
   }

--- a/src/NopeNumber.ts
+++ b/src/NopeNumber.ts
@@ -20,11 +20,13 @@ export class NopeNumber extends NopePrimitive<number> {
   }
 
   public min(size: number, message?: string) {
-    return this.greaterThan(size, message);
+    this.greaterThan(size, message);
+    return this;
   }
 
   public max(size: number, message?: string) {
-    return this.lessThan(size, message);
+    this.lessThan(size, message);
+    return this;
   }
 
   public greaterThan(size: number, message = 'Input is too small') {
@@ -106,11 +108,13 @@ export class NopeNumber extends NopePrimitive<number> {
   }
 
   public positive(message = 'Input must be positive') {
-    return this.greaterThan(0, message);
+    this.greaterThan(0, message);
+    return this;
   }
 
   public negative(message = 'Input must be negative') {
-    return this.lessThan(0, message);
+    this.lessThan(0, message);
+    return this;
   }
 
   public validate(entry?: any, context?: Record<string | number, unknown>): string | undefined {

--- a/src/NopePrimitive.ts
+++ b/src/NopePrimitive.ts
@@ -1,6 +1,6 @@
 import { Validatable, Nil, Rule, AsyncRule, Context } from './types';
 import { NopeReference } from './NopeReference';
-import { resolveNopeRefsFromKeys, every, resolveNopeRef, runValidators } from './utils';
+import { resolveNopeRefsFromKeys, every, resolveNopeRef, runValidators, isNil } from './utils';
 
 export abstract class NopePrimitive<T> implements Validatable<T> {
   protected validationRules: (Rule<T> | AsyncRule<T>)[] = [];
@@ -11,7 +11,7 @@ export abstract class NopePrimitive<T> implements Validatable<T> {
   }
 
   protected isEmpty(entry: T | Nil) {
-    return entry === undefined || entry === null;
+    return isNil(entry);
   }
 
   public required(message = 'This field is required') {

--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -1,6 +1,7 @@
 import { NopePrimitive } from './NopePrimitive';
 import { Nil, Rule } from './types';
 import { urlRegex, emailRegex } from './consts';
+import { isNil } from './utils';
 
 export class NopeString extends NopePrimitive<string> {
   protected _type = 'string';
@@ -21,7 +22,7 @@ export class NopeString extends NopePrimitive<string> {
   }
 
   protected isEmpty(value: string | Nil): boolean {
-    return value === undefined || value === null || `${value}`.trim().length === 0;
+    return isNil(value) || `${value}`.trim().length === 0;
   }
 
   public regex(regex: RegExp, message = "Doesn't satisfy the rule"): this {
@@ -39,19 +40,23 @@ export class NopeString extends NopePrimitive<string> {
   }
 
   public url(message = 'Input is not a valid url'): this {
-    return this.regex(urlRegex, message);
+    this.regex(urlRegex, message);
+    return this;
   }
 
   public email(message = 'Input is not a valid email'): this {
-    return this.regex(emailRegex, message);
+    this.regex(emailRegex, message);
+    return this;
   }
 
   public min(length: number, message?: string): this {
-    return this.greaterThan(length, message);
+    this.greaterThan(length, message);
+    return this;
   }
 
   public max(length: number, message?: string): this {
-    return this.lessThan(length, message);
+    this.lessThan(length, message);
+    return this;
   }
 
   public greaterThan(length: number, message = 'Input is too short'): this {

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -34,4 +34,17 @@ describe('#utils', () => {
       expect(utils.getFromPath('a.b.c[1].d', { a: { b: { c: [2, { d: 5 }] } } })).toBe(5);
     });
   });
+
+  describe('#isNill alias for (null or undefined)', () => {
+    it('should work', () => {
+      expect(utils.isNil(null)).toBe(true);
+      expect(utils.isNil(undefined)).toBe(true);
+      expect(utils.isNil(666)).toBe(false);
+      expect(utils.isNil('six')).toBe(false);
+      expect(utils.isNil(true)).toBe(false);
+      expect(utils.isNil({})).toBe(false);
+      expect(utils.isNil([])).toBe(false);
+      expect(utils.isNil(new Error())).toBe(false);
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,6 +128,6 @@ export function runValidators(tasks: any, entry: any, context: any) {
   }, Promise.resolve());
 }
 
-export function isNil(entry: any): boolean {
+export function isNil(entry: any): entry is Nil {
   return !!(entry === undefined || entry === null);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,3 +127,7 @@ export function runValidators(tasks: any, entry: any, context: any) {
       });
   }, Promise.resolve());
 }
+
+export function isNil(entry: any): boolean {
+  return !!(entry === undefined || entry === null);
+}


### PR DESCRIPTION
# Description

I wrote a method called `isNil` that is a basic alias for `null || undefined`, to avoid rewrite the same code in a lot of places!
I'm using the same PR to fix something that [was required on my first PR](https://github.com/bvego/nope-validator/pull/490#discussion_r642823206).
