### PR TITLE
feature: adding .trim method for Strings

### DIFF
--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -1,6 +1,6 @@
+import { emailRegex, urlRegex } from './consts';
 import { NopePrimitive } from './NopePrimitive';
 import { Nil, Rule } from './types';
-import { urlRegex, emailRegex } from './consts';
 import { isNil } from './utils';
 
 export class NopeString extends NopePrimitive<string> {
@@ -151,6 +151,18 @@ export class NopeString extends NopePrimitive<string> {
       if (value.length !== length) {
         return message;
       }
+    };
+
+    return this.test(rule);
+  }
+
+  public trim() {
+    const rule: Rule<string> = (entry) => {
+      if (this.isEmpty(entry)) {
+        return '';
+      }
+
+      return (entry as string).trim();
     };
 
     return this.test(rule);

--- a/src/__tests__/NopeString.spec.ts
+++ b/src/__tests__/NopeString.spec.ts
@@ -297,4 +297,31 @@ describe('#NopeString', () => {
       await validateSyncAndAsync(Nope.string().exactLength(5, 'msg'), 'lucky', undefined);
     });
   });
+
+  describe('#trim', () => {
+    it('should return a String wihtout whitespace [email]', async () => {
+      const ERR_MSG = 'error-message';
+      const schema = Nope.string().trim().email(ERR_MSG);
+
+      for (const { value, expected } of [
+        { value: ' ftonato@example.com ', expected: 'ftonato@example.com' },
+        { value: ' ftonato@example.io', expected: 'ftonato@example.io' },
+        { value: 'ftonato@example.me ', expected: 'ftonato@example.me' },
+      ]) {
+        await validateSyncAndAsync(schema, value, expected);
+      }
+    });
+
+    it('should return a String wihtout whitespace [required]', async () => {
+      const schema = Nope.string().trim().required('requiredMessage');
+
+      for (const { value, expected } of [
+        { value: ' ftonato ', expected: 'ftonato' },
+        { value: ' ftonato', expected: 'ftonato' },
+        { value: 'ftonato ', expected: 'ftonato' },
+      ]) {
+        await validateSyncAndAsync(schema, value, expected);
+      }
+    });
+  });
 });


### PR DESCRIPTION
# Description
All the description is in the issue #824!

## Usage

```javascript
const EmailSchema = Nope.string().trim().email('Invalid email');
// or
const RequiredSchema = Nope.string().trim().required('Required Message');
// or
const SearchSchema = Nope.object().shape({
  search: Nope.string().trim().required('Please, provide a valid String')
})
```

Fixes #824
