### PR TITLE
feat: add default method for Strings and Numbers

### DIFF
--- a/src/NopeNumber.ts
+++ b/src/NopeNumber.ts
@@ -117,6 +117,18 @@ export class NopeNumber extends NopePrimitive<number> {
     return this;
   }
 
+  public default(value: number) {
+    const rule: Rule<any> = (entry) => {
+      if (this.isEmpty(entry)) {
+        return value;
+      }
+
+      return entry;
+    };
+
+    return this.test(rule);
+  }
+
   public validate(entry?: any, context?: Record<string | number, unknown>): string | undefined {
     const value = !!entry ? Number(entry) : entry;
 

--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -167,4 +167,16 @@ export class NopeString extends NopePrimitive<string> {
 
     return this.test(rule);
   }
+
+  public default(value: string) {
+    const rule: Rule<string> = (entry) => {
+      if (this.isEmpty(entry)) {
+        return value;
+      }
+
+      return entry as string;
+    };
+
+    return this.test(rule);
+  }
 }

--- a/src/__tests__/NopeNumber.spec.ts
+++ b/src/__tests__/NopeNumber.spec.ts
@@ -236,4 +236,33 @@ describe('#NopeNumber', () => {
       await validateSyncAndAsync(Nope.number().integer('integerErrorMessage'), '12', undefined);
     });
   });
+
+  describe('#default', () => {
+    it('should return a default value when entry is empty', async () => {
+      for (const { schema, value, expected } of [
+        {
+          schema: Nope.number().default(5),
+          value: 0.1,
+          expected: 0.1,
+        },
+        {
+          schema: Nope.number().default(10),
+          value: undefined,
+          expected: 10,
+        },
+        {
+          schema: Nope.number().default(15),
+          value: null,
+          expected: 15,
+        },
+        {
+          schema: Nope.number().default(101010),
+          value: 20,
+          expected: 20,
+        },
+      ]) {
+        await validateSyncAndAsync(schema, value, expected);
+      }
+    });
+  });
 });

--- a/src/__tests__/NopeString.spec.ts
+++ b/src/__tests__/NopeString.spec.ts
@@ -324,4 +324,35 @@ describe('#NopeString', () => {
       }
     });
   });
+
+  describe('#default', () => {
+    it('should return a default value when entry is empty', async () => {
+      const ERR_MSG = 'error-message';
+
+      for (const { schema, value, expected } of [
+        {
+          schema: Nope.string().default('default-value').email(ERR_MSG),
+          value: '',
+          expected: 'default-value',
+        },
+        {
+          schema: Nope.string().default('default-value-trim').trim().email(ERR_MSG),
+          value: ' ',
+          expected: 'default-value-trim',
+        },
+        {
+          schema: Nope.string().default('_ftonato ').email(ERR_MSG),
+          value: undefined,
+          expected: '_ftonato ',
+        },
+        {
+          schema: Nope.string().trim().default('will-not-assume-this-value').email(ERR_MSG),
+          value: ' aaa ',
+          expected: 'aaa',
+        },
+      ]) {
+        await validateSyncAndAsync(schema, value, expected);
+      }
+    });
+  });
 });


### PR DESCRIPTION
# Description

We would like to be able to have a default value for `String`s and `Number`s when we receive a `Falsy` value.

```javascript
const schema = Nope.string().default('default-value-trim').trim() // 'default-value-trim'
```

See #641
