### PR TITLE
refactor: updating `trim` method for Strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.0.4
+
+Fixes 🔨
+- String
+  - `.trim()`
+
 1.0.3
 
 Added 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nope-validator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nope-validator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "source": "src/index.ts",
   "main": "lib/cjs/index.js",
   "umd:main": "lib/umd/index.js",

--- a/src/NopeNumber.ts
+++ b/src/NopeNumber.ts
@@ -92,7 +92,7 @@ export class NopeNumber extends NopePrimitive<number> {
     atMostMessage = 'Input is too large',
   ) {
     if (sizeStart && sizeEnd && sizeStart > sizeEnd) {
-      const rule: Rule<unknown> = () => {
+      const rule: Rule<any> = () => {
         throw Error(
           'between must receive an initial size (sizeStart) smaller than the final size (sizeEnd) parameter',
         );

--- a/src/NopeString.ts
+++ b/src/NopeString.ts
@@ -22,7 +22,7 @@ export class NopeString extends NopePrimitive<string> {
   }
 
   protected isEmpty(value: string | Nil): boolean {
-    return isNil(value) || `${value}`.trim().length === 0;
+    return isNil(value) || value.trim().length === 0;
   }
 
   public regex(regex: RegExp, message = "Doesn't satisfy the rule"): this {
@@ -126,7 +126,7 @@ export class NopeString extends NopePrimitive<string> {
     atMostMessage = 'Input is too long',
   ) {
     if (startLength && endLength && startLength > endLength) {
-      const rule: Rule<unknown> = () => {
+      const rule: Rule<any> = () => {
         throw Error(
           'between must receive an initial length (startLength) smaller than the final length (endLength) parameter',
         );
@@ -157,12 +157,9 @@ export class NopeString extends NopePrimitive<string> {
   }
 
   public trim() {
-    const rule: Rule<string> = (entry) => {
-      if (this.isEmpty(entry)) {
-        return '';
-      }
-
-      return (entry as string).trim();
+    const rule: Rule<string> = (entry): any => {
+      this._entry = (entry as string).trim();
+      return;
     };
 
     return this.test(rule);

--- a/src/__tests__/NopeString.spec.ts
+++ b/src/__tests__/NopeString.spec.ts
@@ -299,26 +299,28 @@ describe('#NopeString', () => {
   });
 
   describe('#trim', () => {
-    it('should return a String wihtout whitespace [email]', async () => {
+    it('should remove the whitespace from the entry and return undefined [email]', async () => {
       const ERR_MSG = 'error-message';
       const schema = Nope.string().trim().email(ERR_MSG);
 
       for (const { value, expected } of [
-        { value: ' ftonato@example.com ', expected: 'ftonato@example.com' },
-        { value: ' ftonato@example.io', expected: 'ftonato@example.io' },
-        { value: 'ftonato@example.me ', expected: 'ftonato@example.me' },
+        { value: ' ftonato@example.com ', expected: undefined },
+        { value: ' ftonato@example.io', expected: undefined },
+        { value: 'ftonato@example.me ', expected: undefined },
+        { value: 'ftonato@example.me', expected: undefined },
       ]) {
         await validateSyncAndAsync(schema, value, expected);
       }
     });
 
-    it('should return a String wihtout whitespace [required]', async () => {
+    it('should remove the whitespace from the entry and return undefined [required]', async () => {
       const schema = Nope.string().trim().required('requiredMessage');
 
       for (const { value, expected } of [
-        { value: ' ftonato ', expected: 'ftonato' },
-        { value: ' ftonato', expected: 'ftonato' },
-        { value: 'ftonato ', expected: 'ftonato' },
+        { value: ' space-text-space ', expected: undefined },
+        { value: ' space-text', expected: undefined },
+        { value: 'text-space ', expected: undefined },
+        { value: 'text', expected: undefined },
       ]) {
         await validateSyncAndAsync(schema, value, expected);
       }


### PR DESCRIPTION
# Description
Instead of returning the new String without the whitespaces it should return `undefined` if everything goes well...

Fixes #848
