### PR TITLE
docs: adding no-response workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,37 @@
+name: 🥺 No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for every Monday at 12am
+    - cron: "0 0 * * 1"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  noResponse:
+    if: github.repository == 'ftonato/nope-validator'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🥺 Handle Ghosting
+        uses: actions/stale@v5
+        with:
+          close-issue-message: >
+            This issue has been automatically closed because we haven't received a
+            response from the original author 🙈. This automation helps keep the issue
+            tracker clean from issues that are unactionable. Please reach out if you
+            have more information for us! 🙂
+          close-pr-message: >
+            This PR has been automatically closed because we haven't received a
+            response from the original author 🙈. This automation helps keep the issue
+            tracker clean from PRs that are unactionable. Please reach out if you
+            have more information for us! 🙂
+          days-before-close: 10
+          # don't automatically mark issues/PRs as stale
+          days-before-stale: -1
+          any-of-labels: needs-response
+          labels-to-remove-when-unstale: needs-response


### PR DESCRIPTION
# Description

To avoid scenarios where we need to wait for answers for a long time, after every week branch/issue with no answer will be automatically closed.